### PR TITLE
Set Trustanchorfile to optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class opendkim(
   String                    $canonicalization     = $opendkim::params::canonicalization,
   String                    $removeoldsignatures  = $opendkim::params::removeoldsignatures,
   Optional[Integer]         $maximum_signed_bytes = $opendkim::params::maximum_signed_bytes,
-  String                    $trustanchorfile      = $opendkim::params::trustanchorfile,
+  Optional[String]          $trustanchorfile      = $opendkim::params::trustanchorfile,
   Boolean                   $manage_private_keys  = $opendkim::params::manage_private_keys,
 
 


### PR DESCRIPTION
In https://github.com/lvicainne/puppet-opendkim/pull/19, the parameter `$trustanchorfile` was introduced, without default value (`undef`).
According to the pull request, the trustanchorfile should be optional - which it will be with this pull request.